### PR TITLE
add sample conda notebooks

### DIFF
--- a/graph-studio-conda-interpreter/Graph Studio-Conda – Admin.dsnb
+++ b/graph-studio-conda-interpreter/Graph Studio-Conda – Admin.dsnb
@@ -1,0 +1,649 @@
+[
+  {
+    "name" : "Graph Studio-Conda – Admin",
+    "description" : "Create conda environment and install common packages",
+    "tags" : null,
+    "version" : "6",
+    "layout" : "zeppelin",
+    "type" : "Default",
+    "readOnly" : false,
+    "snapshot" : false,
+    "template" : "dsrgmn3y",
+    "templateConfig" : "{\"visualization\":{\"filters\":[{\"_id\":1583324064459,\"type\":\"styling\",\"enabled\":true,\"conditions\":{\"operator\":\"and\",\"conditions\":[{\"property\":\"hiddenConnection\",\"operator\":\"*\",\"value\":\"\"}]},\"component\":\"edge\",\"target\":\"edge\",\"properties\":{\"colors\":[\"rgba(0, 0, 0, 0.1)\"],\"style\":[\"dashed\"],\"legendTitle\":[\"Hidden Connection\"]}},{\"_id\":1590499315755,\"type\":\"aggregation\",\"enabled\":true,\"conditions\":{\"operator\":\"and\",\"conditions\":[]},\"component\":\"vertex\",\"target\":\"vertex\",\"properties\":{},\"aggregation\":[{\"source\":\"\",\"type\":\"average\"}]}],\"version\":4}}",
+    "paragraphs" : [
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 0,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "# **Graph Studio-Conda - Admin**",
+          "",
+          "This notebook creates a conda environment, installs pandas and matplotlib packages, verifies that the installation was successful, and uploads the environment to be used by a graph user."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674686171369,
+          "endTime" : 1674686171436,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h1 id=\"graph-studio-conda---admin\"><strong>Graph Studio-Conda - Admin</strong></h1>\n<p>This notebook creates a conda environment, installs pandas and matplotlib packages, verifies that the installation was successful, and uploads the environment to be used by a graph user.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 1,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Create conda environment**",
+          "Run the following paragraph to create a conda environment, named \"datascience_environment\", that duplicates the pre-existing environment for python on Graph Studio. This \"basegraph\" environment contains pypgx, which is necessary to interact with in-memory graphs using Python.",
+          "<br />",
+          "<br />",
+          "Note: Creating a conda environment may take several minutes."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674686172904,
+          "endTime" : 1674686172975,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"create-conda-environment\"><strong>Create conda environment</strong></h2>\n<p>Run the following paragraph to create a conda environment, named &quot;datascience_environment&quot;, that duplicates the pre-existing environment for python on Graph Studio. This &quot;basegraph&quot; environment contains pypgx, which is necessary to interact with in-memory graphs using Python.\n<br />\n<br />\nNote: Creating a conda environment may take several minutes.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 2,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "env create -n datascience_environment --file environments/basegraph.yml"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675101215843,
+          "endTime" : 1675102039082,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 3,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Activate Basegraph**",
+          "Run the following paragraph to activate the basegraph environment. If we skip this step, we will not be able to execute some conda commands."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102774191,
+          "endTime" : 1675102774263,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"activate-basegraph\"><strong>Activate Basegraph</strong></h2>\n<p>Run the following paragraph to activate the basegraph environment. If we skip this step, we will not be able to execute some conda commands.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 4,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "activate basegraph"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102540360,
+          "endTime" : 1675102541601,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 5,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Check the environment was created**",
+          "Run the following paragraph to list all local conda environments (conda environments that were created or downloaded in this session).",
+          "<br/>",
+          "You should see the environment we just created is listed."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674749527776,
+          "endTime" : 1674749528049,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"check-the-environment-was-created\"><strong>Check the environment was created</strong></h2>\n<p>Run the following paragraph to list all local conda environments (conda environments that were created or downloaded in this session).\n<br/>\nYou should see the environment we just created is listed.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 6,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "list-local-envs"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102272829,
+          "endTime" : 1675102275204,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 7,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Activate the conda environment and install Python packages**",
+          "Run the following three paragraphs to activate the conda environment you created, and install the pandas and matplotlib packages."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674750176575,
+          "endTime" : 1674750176643,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"activate-the-conda-environment-and-install-python-packages\"><strong>Activate the conda environment and install Python packages</strong></h2>\n<p>Run the following three paragraphs to activate the conda environment you created, and install the pandas and matplotlib packages.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 8,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "activate datascience_environment"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102281615,
+          "endTime" : 1675102282820,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 9,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "install pandas"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102286256,
+          "endTime" : 1675102347030,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 10,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "install matplotlib"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102398649,
+          "endTime" : 1675102462162,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 11,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Verify package installation**",
+          "Run the following paragraph to verify that pandas and matplotlib have been installed, and that the basegraph environment was copied to this environment. <br/>",
+          "Importing pandas and matplotlib in a *python-pgx* paragraph is sufficient to confirm the packages were installed, and by calling *session*, we can confirm that the environment has pypgx installed."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674750433647,
+          "endTime" : 1674750433715,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"verify-package-installation\"><strong>Verify package installation</strong></h2>\n<p>Run the following paragraph to verify that pandas and matplotlib have been installed, and that the basegraph environment was copied to this environment. <br/>\nImporting pandas and matplotlib in a <em>python-pgx</em> paragraph is sufficient to confirm the packages were installed, and by calling <em>session</em>, we can confirm that the environment has pypgx installed.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 12,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "import pandas",
+          "import matplotlib",
+          "session"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102509608,
+          "endTime" : 1675102511453,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 13,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Upload the conda environment to Object Storage so it can be accessed by other users**",
+          "Run the following paragraphs to reactivate the basegraph and upload your environment to object storage with a description attached. This description can be seen when a user lists their available environment, so a meaningful description is helpful when there are multiple environments available."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102728059,
+          "endTime" : 1675102728135,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"upload-the-conda-environment-to-object-storage-so-it-can-be-accessed-by-other-users\"><strong>Upload the conda environment to Object Storage so it can be accessed by other users</strong></h2>\n<p>Run the following paragraphs to reactivate the basegraph and upload your environment to object storage with a description attached. This description can be seen when a user lists their available environment, so a meaningful description is helpful when there are multiple environments available.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 14,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "activate basegraph"
+        ],
+        "selectedVisualization" : null,
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : null,
+        "result" : null,
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 15,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "upload datascience_environment --description 'environment with DS tools' "
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675102549982,
+          "endTime" : 1675102633595,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 16,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Optional: Deactivate your conda environment**",
+          "The conda environment expires when your Graph Studio session expires, but you can optionally deactivate it with the following paragraph."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : true,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674750688290,
+          "endTime" : 1674750688361,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"optional-deactivate-your-conda-environment\"><strong>Optional: Deactivate your conda environment</strong></h2>\n<p>The conda environment expires when your Graph Studio session expires, but you can optionally deactivate it with the following paragraph.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 17,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "deactivate"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674232188181,
+          "endTime" : 1674232189502,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      }
+    ]
+  }
+]

--- a/graph-studio-conda-interpreter/Graph Studio-Conda – Graph User.dsnb
+++ b/graph-studio-conda-interpreter/Graph Studio-Conda – Graph User.dsnb
@@ -1,0 +1,675 @@
+[
+  {
+    "name" : "Graph Studio-Conda – Graph User",
+    "description" : null,
+    "tags" : null,
+    "version" : "6",
+    "layout" : "zeppelin",
+    "type" : "Default",
+    "readOnly" : false,
+    "snapshot" : false,
+    "template" : "dsrgmn3y",
+    "templateConfig" : "{\"visualization\":{\"filters\":[{\"_id\":1583324064459,\"type\":\"styling\",\"enabled\":true,\"conditions\":{\"operator\":\"and\",\"conditions\":[{\"property\":\"hiddenConnection\",\"operator\":\"*\",\"value\":\"\"}]},\"component\":\"edge\",\"target\":\"edge\",\"properties\":{\"colors\":[\"rgba(0, 0, 0, 0.1)\"],\"style\":[\"dashed\"],\"legendTitle\":[\"Hidden Connection\"]}},{\"_id\":1590499315755,\"type\":\"aggregation\",\"enabled\":true,\"conditions\":{\"operator\":\"and\",\"conditions\":[]},\"component\":\"vertex\",\"target\":\"vertex\",\"properties\":{},\"aggregation\":[{\"source\":\"\",\"type\":\"average\"}]}],\"version\":4}}",
+    "paragraphs" : [
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 0,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "# **Example of Conda Interpreter for Data Science User**",
+          "",
+          "## **Step 1: Download and activate Conda Environment**",
+          "Conda environments must be created by the Admin user."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674238487518,
+          "endTime" : 1674238487586,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h1 id=\"example-of-conda-interpreter-for-data-science-user\"><strong>Example of Conda Interpreter for Data Science User</strong></h1>\n<h2 id=\"step-1-download-and-activate-conda-environment\"><strong>Step 1: Download and activate Conda Environment</strong></h2>\n<p>Conda environments must be created by the Admin user.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 1,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda ",
+          "",
+          "list-saved-envs"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103403990,
+          "endTime" : 1675103406175,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 2,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "download datascience_environment"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103471767,
+          "endTime" : 1675103521186,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 3,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Step 2: Activate the conda environment**",
+          "List the local environments to see what you have downloaded, and then activate the environment. ",
+          "All environments that have been downloaded will be listed when list local environments."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675104411009,
+          "endTime" : 1675104411117,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"step-2-activate-the-conda-environment\"><strong>Step 2: Activate the conda environment</strong></h2>\n<p>List the local environments to see what you have downloaded, and then activate the environment.\nAll environments that have been downloaded will be listed when list local environments.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 4,
+        "width" : 0,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "list-local-envs"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103619854,
+          "endTime" : 1675103622085,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 5,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%conda",
+          "",
+          "activate datascience_environment"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103627845,
+          "endTime" : 1675103629068,
+          "interpreter" : "conda",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 6,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Step 3: Load Graph into Memory**",
+          "We will use the Bank Graph as an example. We can run the following paragraph to load the graph into memory, so we can run graph algorithms on it. "
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675104245773,
+          "endTime" : 1675104245858,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"step-3-load-graph-into-memory\"><strong>Step 3: Load Graph into Memory</strong></h2>\n<p>We will use the Bank Graph as an example. We can run the following paragraph to load the graph into memory, so we can run graph algorithms on it.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 7,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "GRAPH_NAME=\"BANK_GRAPH\";",
+          "# try getting the graph from the in-memory graph server",
+          "graph = session.get_graph(GRAPH_NAME);",
+          "# if it does not exist read it into memory",
+          "if (graph == None) :",
+          "    session.read_graph_by_name(GRAPH_NAME, \"pg_view\")",
+          "    print(\"Graph \"+ GRAPH_NAME + \" successfully loaded\")",
+          "    graph = session.get_graph(GRAPH_NAME);",
+          "else :",
+          "    print(\"Graph '\"+ GRAPH_NAME + \"' already loaded\");"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103666652,
+          "endTime" : 1675103674874,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 8,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Step 4: Run pagerank algorithm on the graph**",
+          "Pagerank measures the importance of each node within the graph, based on the number incoming relationships and the importance of the corresponding source nodes."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675104255567,
+          "endTime" : 1675104255661,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"step-4-run-pagerank-algorithm-on-the-graph\"><strong>Step 4: Run pagerank algorithm on the graph</strong></h2>\n<p>Pagerank measures the importance of each node within the graph, based on the number incoming relationships and the importance of the corresponding source nodes.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 9,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "# This paragraph will run the pagerank algorithm, and add pagerank and pagerank_2 as properties to each node",
+          "graph.get_or_create_vertex_property(\"pagerank\", data_type='double', dim=0)",
+          "analyst = session.create_analyst()",
+          "analyst.pagerank(graph, tol=0.001, damping=0.85, max_iter=100, norm=False, rank='pagerank');"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103715115,
+          "endTime" : 1675103715700,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 10,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Step 5: Query in PGQL**",
+          "",
+          "Run the following paragraph to query the BANK_GRAPH. This will return a result set which we can then print. Later in the notebook, we will use this result set with some common Data Science conda packages."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675104273332,
+          "endTime" : 1675104273416,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"step-5-query-in-pgql\"><strong>Step 5: Query in PGQL</strong></h2>\n<p>Run the following paragraph to query the BANK_GRAPH. This will return a result set which we can then print. Later in the notebook, we will use this result set with some common Data Science conda packages.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 11,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%pgql-pgx",
+          "",
+          "/* We can use the pgql paragraphs in Graph Studio to easily find the query we want to generate a result set for. */",
+          "SELECT a.acct_id, a.pagerank_2 as pagerank FROM MATCH (a) ON bank_graph ORDER BY acct_id asc"
+        ],
+        "selectedVisualization" : "table",
+        "visualizationConfig" : "[{\"table\":{\"version\":1}}]",
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103849247,
+          "endTime" : 1675103849694,
+          "interpreter" : "pgql-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 12,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "# Import pandas, which was initially installed as a part of the conda environment. ",
+          "import pandas",
+          "",
+          "# Generate a result set based on the query we made in the previous paragraph, and convert it to",
+          "rs = graph.execute_pgql(\"SELECT a.acct_id, a.pagerank_2 as pagerank FROM MATCH (a) ON bank_graph ORDER BY acct_id asc\")",
+          "result_df = rs.to_pandas()",
+          "print(result_df)"
+        ],
+        "selectedVisualization" : "table",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675103857431,
+          "endTime" : 1675103858328,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 13,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%md",
+          "## **Step 6: Use result set for analytics use case**",
+          "",
+          "In the following paragraphs, we can use the packages installed by the conda interpreter to gain more insights into our data. ",
+          "Specifically, in this example, we can gather more information on the pagerank values for each account."
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : true,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : true,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1675104290922,
+          "endTime" : 1675104291016,
+          "interpreter" : "md",
+          "taskStatus" : "SUCCESS",
+          "status" : "SUCCESS",
+          "results" : [
+            {
+              "message" : "<h2 id=\"step-6-use-result-set-for-analytics-use-case\"><strong>Step 6: Use result set for analytics use case</strong></h2>\n<p>In the following paragraphs, we can use the packages installed by the conda interpreter to gain more insights into our data.\nSpecifically, in this example, we can gather more information on the pagerank values for each account.</p>\n",
+              "type" : "HTML"
+            }
+          ],
+          "forms" : "[]"
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 14,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "result_df.describe()"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674236074466,
+          "endTime" : 1674236075117,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 15,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "# Calculate the standard deviation of the given set of numbers, DataFrame, column, and rows",
+          "result_df.std()"
+        ],
+        "selectedVisualization" : "raw",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674236099395,
+          "endTime" : 1674236099971,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 16,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "import matplotlib.pyplot as plt",
+          "",
+          "result_df.plot()",
+          "plt.show()"
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674236174724,
+          "endTime" : 1674236175461,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      },
+      {
+        "row" : 0,
+        "col" : 0,
+        "sizeX" : 0,
+        "order" : 17,
+        "width" : 12,
+        "title" : null,
+        "hasTitle" : false,
+        "message" : [
+          "%python-pgx",
+          "",
+          "rs_df = graph.execute_pgql(\"SELECT a.acct_id, a.pagerank_2 as pagerank FROM MATCH (a) ON bank_graph\").to_pandas()",
+          "df = rs_df.sort_values(by='acct_id', ascending=False)",
+          "accounts = df['acct_id']",
+          "values = df['pagerank']",
+          "plt.bar(accounts, values, color ='maroon', width = 0.4)",
+          "plt.xlabel(\"Account ID\")",
+          "plt.ylabel(\"Page Rank Value\")",
+          "plt.title(\"Page Rank Value by Account ID\")",
+          "plt.show()"
+        ],
+        "selectedVisualization" : "html",
+        "visualizationConfig" : null,
+        "hideCode" : false,
+        "hideResult" : false,
+        "hideGutter" : true,
+        "hideVizConfig" : false,
+        "hideInIFrame" : false,
+        "forms" : "[]",
+        "result" : {
+          "startTime" : 1674236165333,
+          "endTime" : 1674236167934,
+          "interpreter" : "python-pgx",
+          "taskStatus" : null,
+          "status" : null,
+          "results" : null,
+          "forms" : null
+        },
+        "relations" : [ ],
+        "dynamicFormParams" : null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request adds a folder containing two sample notebooks for the the Graph Studio Conda Interpreter. One for the Admin user, which creates a conda environment and one for the Graph user, which uses the environment for an analytics use case.